### PR TITLE
Ensure Railtie has eager_load_paths

### DIFF
--- a/lib/deface/railtie.rb
+++ b/lib/deface/railtie.rb
@@ -46,7 +46,7 @@ module Deface
       end
 
       railties.each do |railtie|
-        next unless railtie.respond_to? :root
+        next unless railtie.respond_to?(:root) && railtie.config.respond_to?(:eager_load_paths)
         railtie.config.eager_load_paths.reject! {|path| path  =~ /app\/overrides\z/ }
       end
     end


### PR DESCRIPTION
It is possible that gems may define a Railtie without defining
`eager_load_paths` (such as `dotenv-rails`), which causes this function
to fail. Extend the `next` clause to ensure the existence of
`eager_load_paths` to prevent this failure.